### PR TITLE
Drop little-used type aliases

### DIFF
--- a/skstore/ts/src/prv/skstore_internal_types.ts
+++ b/skstore/ts/src/prv/skstore_internal_types.ts
@@ -51,6 +51,3 @@ declare const twriter: unique symbol;
 export type TWriter<K extends T<any> = JSONID, V extends T<any> = JSONFile> = T<
   typeof twriter
 > & { [p]: [K, V] };
-
-export type VectorCJSON = Vector<CJSON>;
-export type VectorPairStringCJSON = Vector<Pair<String, CJSON>>;

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -276,23 +276,26 @@ function clone<T>(value: T): T {
   }
 }
 
+type PartialCJObj = Internal.Vector<Internal.Pair<Internal.String, Internal.CJSON>>;
+type PartialCJArray = Internal.Vector<Internal.CJSON>;
+
 interface FromWasm extends WasmAccess {
-  SKIP_SKJSON_startCJObject: () => ptr<Internal.VectorPairStringCJSON>;
+  SKIP_SKJSON_startCJObject: () => ptr<PartialCJObj>;
   SKIP_SKJSON_addToCJObject: (
-    obj: ptr<Internal.VectorPairStringCJSON>,
+    obj: ptr<PartialCJObj>,
     name: ptr<Internal.String>,
     value: ptr<Internal.CJSON>,
   ) => void;
   SKIP_SKJSON_endCJObject: (
-    obj: ptr<Internal.VectorPairStringCJSON>,
+    obj: ptr<PartialCJObj>,
   ) => ptr<Internal.CJObject>;
-  SKIP_SKJSON_startCJArray: () => ptr<Internal.VectorCJSON>;
+  SKIP_SKJSON_startCJArray: () => ptr<PartialCJArray>;
   SKIP_SKJSON_addToCJArray: (
-    arr: ptr<Internal.VectorCJSON>,
+    arr: ptr<PartialCJArray>,
     value: ptr<Internal.CJSON>,
   ) => void;
   SKIP_SKJSON_endCJArray: (
-    arr: ptr<Internal.VectorCJSON>,
+    arr: ptr<PartialCJArray>,
   ) => ptr<Internal.CJArray>;
   SKIP_SKJSON_createCJNull: () => ptr<Internal.CJNull>;
   SKIP_SKJSON_createCJInt: (v: int) => ptr<Internal.CJInt>;


### PR DESCRIPTION
... and use aliases at their use site which are more opaque / existential in spirit than the specific representation structure